### PR TITLE
Refactor delete handler and show company name on job cards

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -39,6 +39,8 @@ const JobCard: React.FC<JobCardProps> = ({ job, onClick, cardSize = 'medium' }) 
     opacity: isDragging ? 0.5 : 1,
   };
 
+  const cardTitle = job.company && job.company.trim() ? job.company : job.customer_name;
+
   return (
     <div
       ref={setNodeRef}
@@ -62,7 +64,7 @@ const JobCard: React.FC<JobCardProps> = ({ job, onClick, cardSize = 'medium' }) 
         {cardSize === 'compact' && (
           <>
             <div className="flex justify-between items-baseline">
-              <h4 className="font-semibold text-gray-800 truncate">{job.customer_name}</h4>
+              <h4 className="font-semibold text-gray-800 truncate">{cardTitle}</h4>
               <span className="text-xs font-mono text-gray-500 ml-1">#{job.job_number}</span>
             </div>
             {daysUntilDue && (
@@ -79,7 +81,7 @@ const JobCard: React.FC<JobCardProps> = ({ job, onClick, cardSize = 'medium' }) 
         {cardSize === 'medium' && (
           <>
             <div className="flex justify-between items-baseline mb-1">
-              <h4 className="font-semibold text-gray-800 truncate">{job.customer_name}</h4>
+              <h4 className="font-semibold text-gray-800 truncate">{cardTitle}</h4>
               <span className="text-xs font-mono text-gray-500">#{job.job_number}</span>
             </div>
             <p className="text-sm text-gray-600 truncate">{job.material}</p>
@@ -100,10 +102,12 @@ const JobCard: React.FC<JobCardProps> = ({ job, onClick, cardSize = 'medium' }) 
         {cardSize === 'large' && (
           <>
             <div className="flex justify-between items-baseline mb-2">
-              <h4 className="font-semibold text-gray-800">{job.customer_name}</h4>
+              <h4 className="font-semibold text-gray-800">{cardTitle}</h4>
               <span className="text-xs font-mono text-gray-500">#{job.job_number}</span>
             </div>
-            {job.company && <p className="text-sm text-gray-700 mb-1">Company: {job.company}</p>}
+            {job.company && job.company.trim() && (
+              <p className="text-sm text-gray-700 mb-1">Customer: {job.customer_name}</p>
+            )}
             <p className="text-sm text-gray-600 mb-1">Material: {job.material}</p>
             {/* Machine property removed as it doesn't exist in the Job interface */}
             {job.status && <p className="text-sm text-gray-600 mb-1">Status: {job.status}</p>}

--- a/src/components/JobForm.tsx
+++ b/src/components/JobForm.tsx
@@ -288,9 +288,11 @@ const JobForm: React.FC<JobFormProps> = ({ job, onSubmit, onCancel, onSketchSave
               type="button" 
               onClick={() => {
                 if (window.confirm('Are you sure you want to delete this job? This action cannot be undone.')) {
-                  job.id && onDelete(job.id);
+                  if (job.id) {
+                    onDelete(job.id);
+                  }
                 }
-              }} 
+              }}
               title="Delete Job"
               className="p-1 rounded-full text-red-500 hover:bg-red-50 hover:text-red-700"
             >


### PR DESCRIPTION
## Summary
- ensure delete button calls handler only when job id is present
- show company name as the primary job card title, falling back to customer name and listing the customer when available

## Testing
- `pnpm lint` *(fails: React Hook rules violations and `any` types in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_6891a3a479808329b2ccf5061544051e