### PR TITLE
Fix archived search crashes and clean lint issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,17 +98,22 @@ function App() {
 
   useEffect(() => {
     fetchJobs();
-    }, [fetchJobs]);
+  }, [fetchJobs]);
 
   const filteredJobs = useMemo(() => {
     if (!searchQuery) {
       return jobs;
     }
-        return jobs.filter(job => {
-      const query = searchQuery.toLowerCase();
+
+    const query = searchQuery.toLowerCase();
+
+    return jobs.filter(job => {
+      const customerName = String(job.customer_name || '').toLowerCase();
+      const jobNumber = String(job.job_number || '').toLowerCase();
+
       return (
-        job.customer_name.toLowerCase().includes(query) ||
-        job.job_number.includes(query) // Job number is a string, so 'includes' works well.
+        customerName.includes(query) ||
+        jobNumber.includes(query)
       );
     });
   }, [jobs, searchQuery]);
@@ -140,7 +145,7 @@ function App() {
     setIsFormVisible(true);
   };
 
-    const handleSketchSave = async (jobId: string, sketchData: string) => {
+  const handleSketchSave = async (jobId: string, sketchData: string) => {
     try {
       await updateJob(jobId, { sketch_data: sketchData });
       fetchJobs(); // Refresh data to ensure consistency
@@ -168,7 +173,7 @@ function App() {
     }
   };
 
-    const handleFormSubmit = async (formData: JobFormData) => {
+  const handleFormSubmit = async (formData: JobFormData) => {
     try {
       if (selectedJob) {
         await updateJob(selectedJob.id, formData);
@@ -184,7 +189,7 @@ function App() {
     }
   };
 
-    const handleDragStart = (event: DragStartEvent) => {
+  const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;
     const job = jobs.find(j => String(j.id) === String(active.id));
     if (job) {
@@ -208,22 +213,22 @@ function App() {
         return prevJobs;
       }
 
+      const previousJobs = prevJobs;
       const newJobs = prevJobs.map(job =>
         String(job.id) === activeId ? { ...job, status: newStatus } : job
       );
 
-      // Asynchronously update the backend
-      (async () => {
-        const result = await updateJob(activeId, { status: newStatus });
-        // The service now returns an object with a potential error property
-        if (result && 'error' in result) {
-          setError(`Failed to move job: ${(result.error as any).message || 'Unknown error'}`);
-          // Revert to the original state if the backend update fails
-          setJobs(prevJobs);
+      void (async () => {
+        try {
+          await updateJob(activeId, { status: newStatus });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          setError(`Failed to move job: ${message}`);
+          setJobs(previousJobs);
         }
       })();
 
-            return newJobs;
+      return newJobs;
     });
 
     setActiveJob(null);

--- a/src/components/ArchivedJobsModal.tsx
+++ b/src/components/ArchivedJobsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Job } from '../types/job';
 import { getArchivedJobs, updateJob } from '../services/jobService';
 
@@ -47,15 +47,40 @@ const ArchivedJobsModal: React.FC<ArchivedJobsModalProps> = ({ isOpen, onClose, 
     }
   };
 
-  const filteredJobs = archivedJobs.filter(job => {
-    const query = searchQuery.toLowerCase();
-    return (
-      job.job_number.toLowerCase().includes(query) ||
-      job.customer_name.toLowerCase().includes(query) ||
-      job.company?.toLowerCase().includes(query) ||
-      job.material?.toLowerCase().includes(query)
-    );
-  });
+  const filteredJobs = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    const includesQuery = (value: unknown) => {
+      if (value == null) {
+        return false;
+      }
+
+      const text = typeof value === 'string' ? value : String(value);
+      return text.toLowerCase().includes(normalizedQuery);
+    };
+
+    return archivedJobs.reduce<Job[]>((acc, job) => {
+      if (!job) {
+        return acc;
+      }
+
+      if (!normalizedQuery) {
+        acc.push(job);
+        return acc;
+      }
+
+      if (
+        includesQuery(job.job_number) ||
+        includesQuery(job.customer_name) ||
+        includesQuery(job.company) ||
+        includesQuery(job.material)
+      ) {
+        acc.push(job);
+      }
+
+      return acc;
+    }, []);
+  }, [archivedJobs, searchQuery]);
 
   if (!isOpen) return null;
 

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Job } from '../types/job';
 import { Group } from '@visx/group';
 import { scaleTime } from '@visx/scale';
@@ -9,8 +9,9 @@ import { useTooltip, useTooltipInPortal, defaultStyles } from '@visx/tooltip';
 import { localPoint } from '@visx/event';
 import { Zoom } from '@visx/zoom';
 import { timeMinute, timeHour } from 'd3-time';
+import type { ScaleTime } from 'd3-scale';
+import type { ProvidedZoom, ZoomState } from '@visx/zoom/lib/types';
 
-// Define interface for component props
 interface GanttChartProps {
   jobs: Job[];
   width?: number;
@@ -33,7 +34,12 @@ interface GanttTask {
 
 type DragOperation = 'move' | 'resize-start' | 'resize-end' | null;
 
-// Chart dimensions
+interface DragStartSnapshot {
+  x: number;
+  startDate: Date;
+  endDate: Date;
+}
+
 const margin = { top: 20, right: 60, bottom: 100, left: 60 };
 const DRAG_HANDLE_WIDTH = 8;
 
@@ -46,44 +52,557 @@ const tooltipStyles = {
   fontSize: '12px',
 };
 
-const GanttChart: React.FC<GanttChartProps> = ({ 
-  jobs, 
-  width: initialWidth = window.innerWidth - 32, // Default to window width minus padding
-  height = 300, // Reduced height since we only have one row
+interface GanttZoomContentProps {
+  zoom: ProvidedZoom<SVGSVGElement> & ZoomState;
+  width: number;
+  height: number;
+  rowHeight: number;
+  xMax: number;
+  margin: typeof margin;
+  ganttTasks: GanttTask[];
+  hugeDomain: [Date, Date];
+  xScale: ScaleTime<number, number>;
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  jobs: Job[];
+  onJobClick: (job: Job) => void;
+  onMouseDown: (event: React.MouseEvent, task: GanttTask, operation: DragOperation) => void;
+  dragOperation: DragOperation;
+  draggedTask: GanttTask | null;
+  dragStartPosition: DragStartSnapshot | null;
+  setDraggedTask: React.Dispatch<React.SetStateAction<GanttTask | null>>;
+  handleDragEnd: () => void;
+  getCursorStyle: (operation: DragOperation) => string;
+  panning: boolean;
+  middlePanning: boolean;
+  showTooltip: (args: { tooltipData: GanttTask; tooltipLeft?: number; tooltipTop?: number }) => void;
+  hideTooltip: () => void;
+}
+
+const GanttZoomContent: React.FC<GanttZoomContentProps> = ({
+  zoom,
+  width,
+  height,
+  rowHeight,
+  xMax,
+  margin: chartMargin,
+  ganttTasks,
+  hugeDomain,
+  xScale,
+  svgRef,
+  jobs,
+  onJobClick,
+  onMouseDown,
+  dragOperation,
+  draggedTask,
+  dragStartPosition,
+  setDraggedTask,
+  handleDragEnd,
+  getCursorStyle,
+  panning,
+  middlePanning,
+  showTooltip,
+  hideTooltip,
+}) => {
+  const [visibleDomain, setVisibleDomain] = useState<[Date, Date] | null>(null);
+  const [initialDomainApplied, setInitialDomainApplied] = useState(false);
+  const [initialZoomApplied, setInitialZoomApplied] = useState(false);
+  const marginLeft = chartMargin.left;
+
+  const zoomedXScale = useMemo(() => scaleTime<number>({
+    domain: visibleDomain ?? hugeDomain,
+    range: [0, xMax],
+  }), [visibleDomain, hugeDomain, xMax]);
+
+  const msPerPixel = useMemo(() => {
+    const domain = zoomedXScale.domain();
+    const range = zoomedXScale.range();
+    const visibleTimeRange = domain[1].getTime() - domain[0].getTime();
+    const pixelRange = range[1] - range[0];
+    return pixelRange === 0 ? 0 : visibleTimeRange / pixelRange;
+  }, [zoomedXScale]);
+
+  const handlePan = useCallback((deltaPx: number) => {
+    if (!visibleDomain || deltaPx === 0) {
+      return;
+    }
+
+    const [start, end] = visibleDomain;
+    const domainMs = end.getTime() - start.getTime();
+    const deltaMs = -(deltaPx * domainMs) / xMax;
+    setVisibleDomain([
+      new Date(start.getTime() + deltaMs),
+      new Date(end.getTime() + deltaMs),
+    ]);
+  }, [visibleDomain, xMax]);
+
+  const handleZoomChange = useCallback((scaleFactor: number, centerPx: number) => {
+    if (!visibleDomain || scaleFactor === 0) {
+      return;
+    }
+
+    const [start, end] = visibleDomain;
+    const domainMs = end.getTime() - start.getTime();
+    const centerRatio = centerPx / xMax;
+    const centerTime = start.getTime() + domainMs * centerRatio;
+    const newDomainMs = domainMs / scaleFactor;
+    const newStart = centerTime - newDomainMs * centerRatio;
+    const newEnd = centerTime + newDomainMs * (1 - centerRatio);
+    setVisibleDomain([
+      new Date(newStart),
+      new Date(newEnd),
+    ]);
+  }, [visibleDomain, xMax]);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const scaleFactor = event.deltaY < 0 ? 1.1 : 0.9;
+      const rect = svg.getBoundingClientRect();
+      const svgX = event.clientX - rect.left;
+      handleZoomChange(scaleFactor, svgX - marginLeft);
+    };
+
+    svg.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      svg.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleZoomChange, svgRef, marginLeft]);
+
+  useEffect(() => {
+    const originalDragMove = zoom.dragMove;
+    zoom.dragMove = (event: MouseEvent | React.MouseEvent) => {
+      if (!zoom.isDragging) {
+        return;
+      }
+      const movementX = 'movementX' in event ? event.movementX : 0;
+      handlePan(movementX);
+    };
+
+    return () => {
+      zoom.dragMove = originalDragMove;
+    };
+  }, [zoom, handlePan]);
+
+  const handleDrag = useCallback((clientX: number) => {
+    if (!dragOperation || !dragStartPosition || msPerPixel === 0) {
+      return;
+    }
+
+    const deltaX = clientX - dragStartPosition.x;
+    const deltaMs = deltaX * msPerPixel;
+    let newStart = new Date(dragStartPosition.startDate);
+    let newEnd = new Date(dragStartPosition.endDate);
+
+    if (dragOperation === 'move') {
+      newStart = new Date(newStart.getTime() + deltaMs);
+      newEnd = new Date(newEnd.getTime() + deltaMs);
+    } else if (dragOperation === 'resize-start') {
+      newStart = new Date(newStart.getTime() + deltaMs);
+      if (newStart > newEnd) {
+        newStart = newEnd;
+      }
+    } else if (dragOperation === 'resize-end') {
+      newEnd = new Date(newEnd.getTime() + deltaMs);
+      if (newEnd < newStart) {
+        newEnd = newStart;
+      }
+    }
+
+    setDraggedTask(current => {
+      if (!current) {
+        return current;
+      }
+      return {
+        ...current,
+        start: newStart,
+        end: newEnd,
+      };
+    });
+  }, [dragOperation, dragStartPosition, msPerPixel, setDraggedTask]);
+
+  useEffect(() => {
+    if (!dragOperation || !dragStartPosition) {
+      return;
+    }
+
+    const handleMouseMove = (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handleDrag(event.clientX);
+    };
+
+    const handleMouseUp = (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handleDragEnd();
+    };
+
+    window.addEventListener('mousemove', handleMouseMove, { capture: true });
+    window.addEventListener('mouseup', handleMouseUp, { capture: true });
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = getCursorStyle(dragOperation);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove, { capture: true });
+      window.removeEventListener('mouseup', handleMouseUp, { capture: true });
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, [dragOperation, dragStartPosition, getCursorStyle, handleDrag, handleDragEnd]);
+
+  useEffect(() => {
+    if (dragOperation) {
+      hideTooltip();
+    }
+  }, [dragOperation, hideTooltip]);
+
+  useEffect(() => {
+    if (!ganttTasks.length) {
+      return;
+    }
+
+    const minTime = Math.min(...ganttTasks.map(task => task.start.getTime()));
+    const maxTime = Math.max(...ganttTasks.map(task => task.end.getTime()));
+    const paddedMin = new Date(minTime - 3 * 24 * 60 * 60 * 1000);
+    const paddedMax = new Date(maxTime + 3 * 24 * 60 * 60 * 1000);
+
+    if (!initialDomainApplied) {
+      setVisibleDomain([paddedMin, paddedMax]);
+      setInitialDomainApplied(true);
+    }
+
+    if (!initialZoomApplied) {
+      const domainMs = paddedMax.getTime() - paddedMin.getTime();
+      if (domainMs > 0) {
+        const scaleXFactor = xMax / domainMs;
+        const minDateX = xScale(paddedMin);
+        zoom.setTransformMatrix({
+          scaleX: scaleXFactor,
+          scaleY: 1,
+          translateX: marginLeft - minDateX * scaleXFactor,
+          translateY: 0,
+          skewX: 0,
+          skewY: 0,
+        });
+        setInitialZoomApplied(true);
+      }
+    }
+  }, [ganttTasks, initialDomainApplied, initialZoomApplied, xMax, xScale, zoom, marginLeft]);
+
+  const timeAxisTicks = useMemo(() => {
+    const domain = zoomedXScale.domain();
+    const ms = domain[1].getTime() - domain[0].getTime();
+    if (ms < 2 * 60 * 60 * 1000) {
+      const interval = timeMinute.every(5);
+      return interval ? zoomedXScale.ticks(interval) : zoomedXScale.ticks();
+    }
+    if (ms < 24 * 60 * 60 * 1000) {
+      const interval = timeHour.every(1);
+      return interval ? zoomedXScale.ticks(interval) : zoomedXScale.ticks();
+    }
+    return zoomedXScale.ticks();
+  }, [zoomedXScale]);
+
+  const svgCursor = dragOperation
+    ? getCursorStyle(dragOperation)
+    : zoom.isDragging
+      ? 'grabbing'
+      : (panning || middlePanning)
+        ? 'grab'
+        : 'default';
+
+  return (
+    <>
+      <svg
+        ref={svgRef}
+        width={width}
+        height={height}
+        style={{
+          cursor: svgCursor,
+          touchAction: 'none',
+        }}
+        {...zoom.containerProps}
+        onMouseDown={(event) => {
+          if ((panning || middlePanning) && event.button !== 2) {
+            if (event.button === 1) {
+              event.preventDefault();
+            }
+            zoom.dragStart(event);
+          }
+        }}
+        onMouseMove={(event) => {
+          if (panning || middlePanning) {
+            zoom.dragMove(event);
+          }
+        }}
+        onMouseUp={(event) => {
+          if (panning || middlePanning) {
+            zoom.dragEnd(event);
+          }
+        }}
+        onMouseLeave={(event) => {
+          if (panning || middlePanning) {
+            zoom.dragEnd(event);
+          }
+        }}
+      >
+        <defs>
+          <clipPath id="clip">
+            <rect x={0} y={0} width={xMax} height={rowHeight} />
+          </clipPath>
+        </defs>
+        <rect x={0} y={0} width={width} height={height} fill="#fff" rx={14} />
+        <Group left={chartMargin.left} top={chartMargin.top}>
+          <GridColumns scale={zoomedXScale} height={rowHeight} stroke="#e0e0e0" />
+          <Group clipPath="url(#clip)">
+            {ganttTasks.map(task => {
+              const renderTask = draggedTask && draggedTask.id === task.id ? draggedTask : task;
+              const y = 0;
+              const x = zoomedXScale(renderTask.start);
+              const barWidth = zoomedXScale(renderTask.end) - x;
+              const barHeight = rowHeight;
+
+              if (barWidth <= 0) {
+                return null;
+              }
+
+              const isDragging = draggedTask && draggedTask.id === task.id;
+
+              return (
+                <Group key={`bar-group-${task.id}`}>
+                  <Bar
+                    key={`drag-handle-${task.id}`}
+                    x={x}
+                    y={y}
+                    width={barWidth}
+                    height={10}
+                    fill={task.color}
+                    opacity={isDragging ? 0.7 : 1}
+                    rx={4}
+                    ry={0}
+                    onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'move')}
+                    onMouseMove={(event: React.MouseEvent) => {
+                      if (!dragOperation) {
+                        const point = localPoint(event);
+                        if (!point) {
+                          return;
+                        }
+                        showTooltip({
+                          tooltipData: task,
+                          tooltipLeft: point.x,
+                          tooltipTop: point.y,
+                        });
+                      }
+                    }}
+                    onMouseLeave={() => {
+                      if (!dragOperation) {
+                        hideTooltip();
+                      }
+                    }}
+                    style={{ cursor: 'grab', touchAction: 'none' }}
+                  />
+
+                  <Bar
+                    key={`bar-${task.id}`}
+                    x={x}
+                    y={y + 10}
+                    width={barWidth}
+                    height={barHeight - 10}
+                    fill={task.color}
+                    opacity={isDragging ? 0.7 : 0.85}
+                    rx={0}
+                    ry={4}
+                    onClick={() => {
+                      const jobObj = jobs.find(job => job.id === task.job_id);
+                      if (jobObj) {
+                        onJobClick(jobObj);
+                      }
+                    }}
+                    onMouseMove={(event: React.MouseEvent) => {
+                      if (!dragOperation) {
+                        const point = localPoint(event);
+                        if (!point) {
+                          return;
+                        }
+                        showTooltip({
+                          tooltipData: task,
+                          tooltipLeft: point.x,
+                          tooltipTop: point.y,
+                        });
+                      }
+                    }}
+                    onMouseLeave={() => {
+                      if (!dragOperation) {
+                        hideTooltip();
+                      }
+                    }}
+                    style={{ cursor: 'pointer', touchAction: 'none' }}
+                  />
+
+                  {barWidth > 30 && (
+                    <>
+                      <text
+                        x={x + 5}
+                        y={y + 25}
+                        fontSize={10}
+                        fontWeight="bold"
+                        fill="white"
+                        style={{ pointerEvents: 'none' }}
+                      >
+                        #{task.job_number}
+                      </text>
+                      {barWidth > 60 && (
+                        <text
+                          x={x + 5}
+                          y={y + 38}
+                          fontSize={9}
+                          fill="white"
+                          style={{ pointerEvents: 'none' }}
+                        >
+                          {task.customer_name}
+                        </text>
+                      )}
+                      {barWidth > 90 && task.company && (
+                        <text
+                          x={x + 5}
+                          y={y + 50}
+                          fontSize={8}
+                          fill="white"
+                          style={{ pointerEvents: 'none' }}
+                        >
+                          {task.company}
+                        </text>
+                      )}
+                    </>
+                  )}
+
+                  <Bar
+                    key={`handle-start-${task.id}`}
+                    x={x - DRAG_HANDLE_WIDTH / 2}
+                    y={y}
+                    width={DRAG_HANDLE_WIDTH}
+                    height={barHeight}
+                    fill="rgba(0,0,0,0.2)"
+                    rx={2}
+                    onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'resize-start')}
+                    style={{ cursor: 'ew-resize', touchAction: 'none' }}
+                  />
+
+                  <Bar
+                    key={`handle-end-${task.id}`}
+                    x={x + barWidth - DRAG_HANDLE_WIDTH / 2}
+                    y={y}
+                    width={DRAG_HANDLE_WIDTH}
+                    height={barHeight}
+                    fill="rgba(0,0,0,0.2)"
+                    rx={2}
+                    onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'resize-end')}
+                    style={{ cursor: 'ew-resize', touchAction: 'none' }}
+                  />
+                </Group>
+              );
+            })}
+          </Group>
+        </Group>
+        <AxisBottom
+          top={rowHeight + chartMargin.top}
+          left={chartMargin.left}
+          scale={zoomedXScale}
+          stroke="#333"
+          tickStroke="#333"
+          tickValues={timeAxisTicks}
+          tickFormat={(value) => {
+            const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
+            const domain = zoomedXScale.domain();
+            const ms = domain[1].getTime() - domain[0].getTime();
+            if (ms < 2 * 60 * 60 * 1000) {
+              return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+            }
+            return `${date.getHours()}:00`;
+          }}
+          tickLabelProps={() => ({
+            fill: '#333',
+            fontSize: 10,
+            textAnchor: 'middle',
+          })}
+        />
+        <AxisBottom
+          top={rowHeight + chartMargin.top + 30}
+          left={chartMargin.left}
+          scale={zoomedXScale}
+          stroke="#333"
+          tickStroke="#333"
+          tickFormat={(value) => {
+            const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
+            return date.getDate().toString();
+          }}
+          tickLabelProps={() => ({
+            fill: '#333',
+            fontSize: 11,
+            textAnchor: 'middle',
+          })}
+        />
+        <AxisBottom
+          top={rowHeight + chartMargin.top + 60}
+          left={chartMargin.left}
+          scale={zoomedXScale}
+          stroke="#333"
+          tickStroke="#333"
+          tickFormat={(value) => {
+            const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
+            return new Intl.DateTimeFormat('en-US', { month: 'short' }).format(date);
+          }}
+          tickLabelProps={() => ({
+            fill: '#333',
+            fontSize: 12,
+            textAnchor: 'middle',
+            fontWeight: 'bold',
+          })}
+        />
+      </svg>
+    </>
+  );
+};
+
+const GanttChart: React.FC<GanttChartProps> = ({
+  jobs,
+  width: initialWidth = typeof window !== 'undefined' ? window.innerWidth - 32 : 800,
+  height = 300,
   onJobTimeUpdate = (jobId, start, end) => {
-    // Default implementation logs the update
     console.log('Job time update:', { jobId, start: start.toISOString(), end: end.toISOString() });
   },
   onJobClick = (job) => {
-    // Default implementation logs the click
     console.log('Job clicked:', job.id);
-  }
+  },
 }) => {
   const { showTooltip, hideTooltip, tooltipData, tooltipLeft, tooltipTop } = useTooltip<GanttTask>();
   const { TooltipInPortal } = useTooltipInPortal({ scroll: true });
-  
-  // State for tracking the task being dragged and the drag operation
+
   const [draggedTask, setDraggedTask] = useState<GanttTask | null>(null);
   const [dragOperation, setDragOperation] = useState<DragOperation>(null);
-  const [dragStartPosition, setDragStartPosition] = useState<{ x: number; startDate: Date; endDate: Date } | null>(null);
-  
-  // State for responsive width
+  const [dragStartPosition, setDragStartPosition] = useState<DragStartSnapshot | null>(null);
   const [width, setWidth] = useState(initialWidth);
-
   const svgRef = React.useRef<SVGSVGElement | null>(null);
-
-  // State for panning mode (spacebar or middle mouse)
   const [panning, setPanning] = useState(false);
   const [middlePanning, setMiddlePanning] = useState(false);
 
-  // Listen for spacebar keydown/up to enable panning
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'Space') setPanning(true);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code === 'Space') {
+        setPanning(true);
+      }
     };
-    const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.code === 'Space') setPanning(false);
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.code === 'Space') {
+        setPanning(false);
+      }
     };
+
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
     return () => {
@@ -92,24 +611,33 @@ const GanttChart: React.FC<GanttChartProps> = ({
     };
   }, []);
 
-  // Listen for middle mouse button for panning
   useEffect(() => {
     const svg = svgRef.current;
-    if (!svg) return;
-    const handleMouseDown = (e: MouseEvent) => {
-      if (e.button === 1) {
+    if (!svg) {
+      return;
+    }
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (event.button === 1) {
         setMiddlePanning(true);
-        // Prevent default browser scroll
-        e.preventDefault();
+        event.preventDefault();
       }
     };
-    const handleMouseUp = (e: MouseEvent) => {
-      if (e.button === 1) setMiddlePanning(false);
+
+    const handleMouseUp = (event: MouseEvent) => {
+      if (event.button === 1) {
+        setMiddlePanning(false);
+      }
     };
-    const handleMouseLeave = () => setMiddlePanning(false);
+
+    const handleMouseLeave = () => {
+      setMiddlePanning(false);
+    };
+
     svg.addEventListener('mousedown', handleMouseDown);
     window.addEventListener('mouseup', handleMouseUp);
     svg.addEventListener('mouseleave', handleMouseLeave);
+
     return () => {
       svg.removeEventListener('mousedown', handleMouseDown);
       window.removeEventListener('mouseup', handleMouseUp);
@@ -117,32 +645,30 @@ const GanttChart: React.FC<GanttChartProps> = ({
     };
   }, [svgRef]);
 
-  // Prepare data for the chart
   const ganttTasks: GanttTask[] = useMemo(() => jobs
-    .filter((job: Job) => job.job_start && job.job_end)
-    .map((job: Job) => {
-        let hash = 0;
-        for (let i = 0; i < job.id.length; i++) {
-          hash = job.id.charCodeAt(i) + ((hash << 5) - hash);
-        }
-        const hue = Math.abs(hash % 300);
-        const color = `hsl(${hue}, 70%, 50%)`;
+    .filter((job): job is Job & { job_start: string; job_end: string } => Boolean(job.job_start && job.job_end))
+    .map((job) => {
+      let hash = 0;
+      for (let i = 0; i < job.id.length; i += 1) {
+        hash = job.id.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      const hue = Math.abs(hash % 300);
+      const color = `hsl(${hue}, 70%, 50%)`;
 
-        return {
-            id: `task-${job.id}`,
-            job_id: job.id,
-            job_number: job.job_number || 'No #',
-            customer_name: job.customer_name || 'Unnamed',
-            company: job.company || '',
-            name: `${job.job_number || 'No #'} - ${job.customer_name || 'Unnamed'}`,
-            start: new Date(job.job_start as string),
-            end: new Date(job.job_end as string),
-            color: color
-        };
+      return {
+        id: `task-${job.id}`,
+        job_id: job.id,
+        job_number: job.job_number || 'No #',
+        customer_name: job.customer_name || 'Unnamed',
+        company: job.company || '',
+        name: `${job.job_number || 'No #'} - ${job.customer_name || 'Unnamed'}`,
+        start: new Date(job.job_start as string),
+        end: new Date(job.job_end as string),
+        color,
+      };
     }), [jobs]);
 
-  // Infinite timeline: set a huge domain
-  const hugeDomain = useMemo(() => {
+  const hugeDomain = useMemo<[Date, Date]>(() => {
     const now = new Date();
     const min = new Date(now.getTime());
     min.setFullYear(min.getFullYear() - 50);
@@ -151,96 +677,66 @@ const GanttChart: React.FC<GanttChartProps> = ({
     return [min, max];
   }, []);
 
-  // Chart bounds
   const xMax = width - margin.left - margin.right;
 
-  // Scales
-  const xScale = useMemo(() => {
-    return scaleTime<number>({
-      domain: hugeDomain,
-      range: [0, xMax],
-    });
-  }, [xMax, hugeDomain]);
-  
-  // Calculate the row height for the single row
-  const rowHeight = 80; // Single fixed height for all bars to ensure enough space
+  const xScale = useMemo(() => scaleTime<number>({
+    domain: hugeDomain,
+    range: [0, xMax],
+  }), [xMax, hugeDomain]);
 
-  // Handle drag operations for task bars
+  const rowHeight = 80;
+
   const handleDragStart = useCallback((task: GanttTask, operation: DragOperation, clientX: number) => {
-    // Make a deep copy to avoid mutation issues
     setDraggedTask({
       ...task,
       start: new Date(task.start),
-      end: new Date(task.end)
+      end: new Date(task.end),
     });
-    
     setDragOperation(operation);
     setDragStartPosition({
       x: clientX,
       startDate: new Date(task.start),
-      endDate: new Date(task.end)
+      endDate: new Date(task.end),
     });
   }, []);
 
   const handleDragEnd = useCallback(() => {
-    // Only call onJobTimeUpdate when drag is complete
     if (draggedTask && dragOperation) {
-      // Call the callback once with final values
       onJobTimeUpdate(draggedTask.job_id, draggedTask.start, draggedTask.end);
     }
-    // Clear the drag state
     setDraggedTask(null);
     setDragOperation(null);
+    setDragStartPosition(null);
   }, [draggedTask, dragOperation, onJobTimeUpdate]);
 
-  // Helper function to get cursor style based on drag operation
   const getCursorStyle = useCallback((operation: DragOperation): string => {
     switch (operation) {
-      case 'move': return 'grabbing';
-      case 'resize-start': 
-      case 'resize-end': return 'ew-resize';
-      default: return 'default';
+      case 'move':
+        return 'grabbing';
+      case 'resize-start':
+      case 'resize-end':
+        return 'ew-resize';
+      default:
+        return 'default';
     }
   }, []);
 
-  // Handle window resize for responsiveness
   useEffect(() => {
     const handleResize = () => {
-      setWidth(window.innerWidth - 32); // Adjust width based on window size
-    };
-    
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    const svg = svgRef.current;
-    if (!svg) return;
-    const handleWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      const scale = e.deltaY < 0 ? 1.1 : 0.9;
-      const rect = svg.getBoundingClientRect();
-      // Mouse position in SVG coordinates
-      const svgX = e.clientX - rect.left;
-      const svgY = e.clientY - rect.top;
-      // Pass the SVG coordinates directly as the center
-      if (typeof (window as any).__latestZoom === 'function') {
-        (window as any).__latestZoom(scale, { x: svgX, y: svgY });
+      if (typeof window !== 'undefined') {
+        setWidth(window.innerWidth - 32);
       }
     };
-    svg.addEventListener('wheel', handleWheel, { passive: false });
-    return () => {
-      svg.removeEventListener('wheel', handleWheel);
-    };
-  }, [width, height]);
 
-  // Utility function to handle mouse down events for dragging
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   const onMouseDown = useCallback((event: React.MouseEvent, task: GanttTask, operation: DragOperation) => {
-    // Prevent the event from triggering zoom
     event.stopPropagation();
     event.preventDefault();
-    
-    // Start the drag operation
     handleDragStart(task, operation, event.clientX);
   }, [handleDragStart]);
 
@@ -249,440 +745,36 @@ const GanttChart: React.FC<GanttChartProps> = ({
       <Zoom<SVGSVGElement>
         width={width}
         height={height}
-        scaleXMin={0.01} // allow much deeper zoom in
-        scaleXMax={200} // allow much further zoom out
+        scaleXMin={0.01}
+        scaleXMax={200}
       >
-        {(zoom: any) => {
-          // --- Fix: set initial domain for zoomedXScale to padded job range ---
-          const [, setInitialDomain] = useState<[Date, Date] | null>(null);
-          const [initialZoomed, setInitialZoomed] = useState(false);
-
-          // --- Controlled domain: sync timeline and tasks ---
-          const [visibleDomain, setVisibleDomain] = useState<[Date, Date] | null>(null);
-          const [initialFitted, setInitialFitted] = useState(false);
-
-          // On initial load, set domain to tightly fit jobs and set zoom transform
-          useEffect(() => {
-            if (initialFitted || visibleDomain) return;
-            if (!ganttTasks.length) return;
-            const minDate = new Date(Math.min(...ganttTasks.map(t => t.start.getTime())));
-            const maxDate = new Date(Math.max(...ganttTasks.map(t => t.end.getTime())));
-            const paddedMin = new Date(minDate.getTime() - 3 * 24 * 60 * 60 * 1000);
-            const paddedMax = new Date(maxDate.getTime() + 3 * 24 * 60 * 60 * 1000);
-            setVisibleDomain([paddedMin, paddedMax]);
-            setInitialFitted(true);
-          }, [ganttTasks, visibleDomain, initialFitted]);
-
-          // Remove useEffect that syncs domain from transform matrix
-
-          // Custom pan/zoom handlers to update domain in state
-          const handlePan = useCallback((deltaPx: number) => {
-            if (!visibleDomain) return;
-            const domainMs = visibleDomain[1].getTime() - visibleDomain[0].getTime();
-            const msPerPx = domainMs / xMax;
-            const deltaMs = -deltaPx * msPerPx; // negative for natural direction
-            setVisibleDomain([
-              new Date(visibleDomain[0].getTime() + deltaMs),
-              new Date(visibleDomain[1].getTime() + deltaMs)
-            ]);
-          }, [visibleDomain, xMax]);
-
-          const handleZoom = useCallback((scaleFactor: number, centerPx: number) => {
-            if (!visibleDomain) return;
-            const domainStart = visibleDomain[0].getTime();
-            const domainEnd = visibleDomain[1].getTime();
-            const domainMs = domainEnd - domainStart;
-            const centerRatio = centerPx / xMax;
-            const centerTime = domainStart + domainMs * centerRatio;
-            const newDomainMs = domainMs / scaleFactor;
-            const newStart = centerTime - newDomainMs * centerRatio;
-            const newEnd = centerTime + newDomainMs * (1 - centerRatio);
-            setVisibleDomain([
-              new Date(newStart),
-              new Date(newEnd)
-            ]);
-          }, [visibleDomain, xMax]);
-
-          // Patch visx Zoom event handlers to call our pan/zoom
-          useEffect(() => {
-            (window as any).__latestZoom = (scale: number, center: { x: number; y: number }) => {
-              handleZoom(scale, center.x - margin.left);
-            };
-          }, [handleZoom]);
-
-          // Patch dragStart/dragMove to call our pan
-          useEffect(() => {
-            zoom.dragMove = (e: MouseEvent | React.MouseEvent) => {
-              if (!zoom.isDragging) return;
-              const deltaPx = e.movementX;
-              handlePan(deltaPx);
-            };
-          }, [zoom, handlePan]);
-
-          // --- Use correct domain for zoomedXScale at all times ---
-          const zoomedXScale = useMemo(() => {
-            const scale = scaleTime({
-              domain: visibleDomain || hugeDomain,
-              range: [0, xMax],
-            });
-            return scale;
-          }, [visibleDomain, xMax, hugeDomain]);
-
-          // Calculate msPerPixel based on zoomed scale
-          const msPerPixel = useMemo(() => {
-            const domain = zoomedXScale.domain();
-            const range = zoomedXScale.range();
-            const visibleTimeRange = domain[1].getTime() - domain[0].getTime();
-            const pixelRange = range[1] - range[0];
-            return visibleTimeRange / pixelRange;
-          }, [zoomedXScale]);
-
-          // Drag logic that uses the zoomed msPerPixel
-          const handleDrag = useCallback((clientX: number) => {
-            if (!draggedTask || !dragOperation || !dragStartPosition) {
-              return;
-            }
-            const deltaX = clientX - dragStartPosition.x;
-            const deltaMs = deltaX * msPerPixel;
-            let newStart = new Date(dragStartPosition.startDate);
-            let newEnd = new Date(dragStartPosition.endDate);
-            if (dragOperation === 'move') {
-              newStart = new Date(newStart.getTime() + deltaMs);
-              newEnd = new Date(newEnd.getTime() + deltaMs);
-            } else if (dragOperation === 'resize-start') {
-              newStart = new Date(newStart.getTime() + deltaMs);
-              if (newStart > newEnd) newStart = newEnd;
-            } else if (dragOperation === 'resize-end') {
-              newEnd = new Date(newEnd.getTime() + deltaMs);
-              if (newEnd < newStart) newEnd = newStart;
-            }
-            setDraggedTask({
-              ...draggedTask,
-              start: newStart,
-              end: newEnd
-            });
-          }, [draggedTask, dragOperation, dragStartPosition, msPerPixel]);
-
-          // Move the global mouse event handler useEffect here
-          useEffect(() => {
-            if (!dragOperation || !draggedTask) return;
-            const handleMouseMove = (event: MouseEvent) => {
-              event.preventDefault();
-              event.stopPropagation();
-              handleDrag(event.clientX);
-            };
-            const handleMouseUp = (event: MouseEvent) => {
-              event.preventDefault();
-              event.stopPropagation();
-              handleDragEnd();
-            };
-            window.addEventListener('mousemove', handleMouseMove, { capture: true });
-            window.addEventListener('mouseup', handleMouseUp, { capture: true });
-            document.body.style.userSelect = 'none';
-            document.body.style.cursor = getCursorStyle(dragOperation);
-            return () => {
-              window.removeEventListener('mousemove', handleMouseMove, { capture: true });
-              window.removeEventListener('mouseup', handleMouseUp, { capture: true });
-              document.body.style.userSelect = '';
-              document.body.style.cursor = '';
-            };
-          }, [dragOperation, draggedTask, handleDrag]);
-
-          // Auto-zoom to fit jobs on first render
-          useEffect(() => {
-            if (initialZoomed) return;
-            if (!ganttTasks.length) return;
-            // Find min/max dates from jobs
-            const minDate = new Date(Math.min(...ganttTasks.map(t => t.start.getTime())));
-            const maxDate = new Date(Math.max(...ganttTasks.map(t => t.end.getTime())));
-            // Always pad by ±3 days for initial view
-            const paddedMin = new Date(minDate.getTime() - 3 * 24 * 60 * 60 * 1000);
-            const paddedMax = new Date(maxDate.getTime() + 3 * 24 * 60 * 60 * 1000);
-            setInitialDomain([paddedMin, paddedMax]);
-            // Calculate the scale factor so the padded domain fits the visible area (excluding margin.left)
-            const domainMs = paddedMax.getTime() - paddedMin.getTime();
-            const scaleX = xMax / domainMs;
-            // Align paddedMin with the left edge of the chart (after margin.left)
-            const minDateX = xScale(paddedMin);
-            zoom.setTransformMatrix({
-              scaleX,
-              scaleY: 1,
-              translateX: margin.left - minDateX * scaleX,
-              translateY: 0,
-              skewX: 0,
-              skewY: 0
-            });
-            setInitialZoomed(true);
-          }, [ganttTasks, xScale, xMax, zoom, initialZoomed]);
-
-          return (
-            <>
-              {/* Zoom controls removed as requested */}
-              <svg 
-                ref={svgRef}
-                width={width} 
-                height={height} 
-                style={{ 
-                  cursor: dragOperation
-                    ? getCursorStyle(dragOperation)
-                    : zoom.isDragging
-                      ? 'grabbing'
-                      : (panning || middlePanning)
-                        ? 'grab'
-                        : 'default',
-                  touchAction: 'none'
-                }} 
-                {...zoom.containerProps}
-                onMouseDown={e => {
-                  // Only start panning if spacebar or middle mouse
-                  if ((panning || middlePanning) && e.button !== 2) {
-                    // Prevent default for middle mouse
-                    if (e.button === 1) e.preventDefault();
-                    zoom.dragStart(e);
-                  }
-                }}
-                onMouseMove={e => {
-                  if (panning || middlePanning) zoom.dragMove(e);
-                }}
-                onMouseUp={e => {
-                  if (panning || middlePanning) zoom.dragEnd(e);
-                }}
-                onMouseLeave={e => {
-                  if (panning || middlePanning) zoom.dragEnd(e);
-                }}
-              >
-                <defs>
-                  <clipPath id="clip">
-                    <rect x={0} y={0} width={xMax} height={rowHeight} />
-                  </clipPath>
-                </defs>
-                <rect x={0} y={0} width={width} height={height} fill="#fff" rx={14} />
-                <Group left={margin.left} top={margin.top}>
-                  <GridColumns scale={zoomedXScale} height={rowHeight} stroke="#e0e0e0" />
-                  <Group clipPath="url(#clip)">
-                    {ganttTasks.map((task: GanttTask) => {
-                      // If this task is currently being dragged, use the draggedTask state instead
-                      // This is crucial for visual feedback during dragging
-                      const renderTask = (draggedTask && draggedTask.id === task.id) ? draggedTask : task;
-                      const y = 0; // All tasks in a single row
-                      // Use zoomedXScale for both start and end
-                      const x = zoomedXScale(renderTask.start);
-                      const barWidth = zoomedXScale(renderTask.end) - x;
-                      const barHeight = rowHeight;
-                      if (barWidth <= 0) return null;
-                      
-                      // Determine if this is the task being dragged
-                      const isDragging = draggedTask && draggedTask.id === task.id;
-                      
-                      return (
-                        <Group key={`bar-group-${task.id}`}>
-                          {/* Task drag handle (top portion) */}
-                          <Bar
-                            key={`drag-handle-${task.id}`}
-                            x={x}
-                            y={y}
-                            width={barWidth}
-                            height={10} // Height of the drag handle
-                            fill={task.color}
-                            opacity={isDragging ? 0.7 : 1}
-                            rx={4} // rounded top corners
-                            ry={0} // square bottom corners
-                            onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'move')}
-                            onMouseMove={(event: React.MouseEvent) => {
-                              if (!dragOperation) {
-                                const point = localPoint(event);
-                                if (!point) return;
-                                showTooltip({
-                                  tooltipData: task,
-                                  tooltipLeft: point.x,
-                                  tooltipTop: point.y,
-                                });
-                              }
-                            }}
-                            onMouseLeave={() => {
-                              if (!dragOperation) hideTooltip();
-                            }}
-                            style={{ cursor: 'grab', touchAction: 'none' }}
-                          />
-                          
-                          {/* Main task bar (clickable body) */}
-                          <Bar
-                            key={`bar-${task.id}`}
-                            x={x}
-                            y={y + 10} // Position below the drag handle
-                            width={barWidth}
-                            height={barHeight - 10} // Reduce height to accommodate drag handle
-                            fill={task.color}
-                            opacity={isDragging ? 0.7 : 0.85} // Slightly lighter than the drag handle
-                            rx={0} // square top corners
-                            ry={4} // rounded bottom corners
-                            onClick={() => {
-                              // Find the original job object from jobs prop
-                              const jobObj = jobs.find(job => job.id === task.job_id);
-                              if (jobObj) onJobClick(jobObj);
-                            }}
-                            onMouseMove={(event: React.MouseEvent) => {
-                              if (!dragOperation) {
-                                const point = localPoint(event);
-                                if (!point) return;
-                                showTooltip({
-                                  tooltipData: task,
-                                  tooltipLeft: point.x,
-                                  tooltipTop: point.y,
-                                });
-                              }
-                            }}
-                            onMouseLeave={() => {
-                              if (!dragOperation) hideTooltip();
-                            }}
-                            style={{ cursor: 'pointer', touchAction: 'none' }}
-                          />
-                          {/* Task information text */}
-                          {barWidth > 30 && (
-                            <>
-                              <text
-                                x={x + 5}
-                                y={y + 25}
-                                fontSize={10}
-                                fontWeight="bold"
-                                fill="white"
-                                style={{ pointerEvents: 'none' }}
-                              >
-                                #{task.job_number}
-                              </text>
-                              {barWidth > 60 && (
-                                <text
-                                  x={x + 5}
-                                  y={y + 38}
-                                  fontSize={9}
-                                  fill="white"
-                                  style={{ pointerEvents: 'none' }}
-                                >
-                                  {task.customer_name}
-                                </text>
-                              )}
-                              {barWidth > 90 && task.company && (
-                                <text
-                                  x={x + 5}
-                                  y={y + 50}
-                                  fontSize={8}
-                                  fill="white"
-                                  style={{ pointerEvents: 'none' }}
-                                >
-                                  {task.company}
-                                </text>
-                              )}
-                            </>
-                          )}
-                          {/* Left resize handle */}
-                          <Bar
-                            key={`handle-start-${task.id}`}
-                            x={x - DRAG_HANDLE_WIDTH / 2}
-                            y={y}
-                            width={DRAG_HANDLE_WIDTH}
-                            height={barHeight}
-                            fill="rgba(0,0,0,0.2)"
-                            rx={2}
-                            onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'resize-start')}
-                            style={{ cursor: 'ew-resize', touchAction: 'none' }}
-                          />
-                          
-                          {/* Right resize handle */}
-                          <Bar
-                            key={`handle-end-${task.id}`}
-                            x={x + barWidth - DRAG_HANDLE_WIDTH / 2}
-                            y={y}
-                            width={DRAG_HANDLE_WIDTH}
-                            height={barHeight}
-                            fill="rgba(0,0,0,0.2)"
-                            rx={2}
-                            onMouseDown={(event: React.MouseEvent) => onMouseDown(event, task, 'resize-end')}
-                            style={{ cursor: 'ew-resize', touchAction: 'none' }}
-                          />
-                        </Group>
-                      );
-                    })}
-                  </Group>
-                </Group>
-                {/* Hour/minute level axis */}
-                <AxisBottom
-                  top={rowHeight + margin.top}
-                  left={margin.left}
-                  scale={zoomedXScale}
-                  stroke="#333"
-                  tickStroke="#333"
-                  tickValues={useMemo(() => {
-                    // Use visx scaleTime().ticks() for dynamic granularity
-                    const domain = zoomedXScale.domain();
-                    const ms = domain[1].getTime() - domain[0].getTime();
-                    if (ms < 2 * 60 * 60 * 1000) {
-                      // <2 hours: show every 5 minutes
-                      return zoomedXScale.ticks(timeMinute.every(5));
-                    } else if (ms < 24 * 60 * 60 * 1000) {
-                      // <1 day: show every hour
-                      return zoomedXScale.ticks(timeHour.every(1));
-                    } else {
-                      // Otherwise, let visx pick
-                      return zoomedXScale.ticks();
-                    }
-                  }, [zoomedXScale])}
-                  tickFormat={(value) => {
-                    const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
-                    const domain = zoomedXScale.domain();
-                    const ms = domain[1].getTime() - domain[0].getTime();
-                    if (ms < 2 * 60 * 60 * 1000) {
-                      // <2 hours: show HH:mm
-                      return date.getHours().toString().padStart(2, '0') + ':' + date.getMinutes().toString().padStart(2, '0');
-                    } else {
-                      // Otherwise just hour
-                      return date.getHours() + ':00';
-                    }
-                  }}
-                  tickLabelProps={() => ({ 
-                    fill: '#333', 
-                    fontSize: 10, 
-                    textAnchor: 'middle' 
-                  })}
-                />
-                {/* Day level axis */}
-                <AxisBottom
-                  top={rowHeight + margin.top + 30}
-                  left={margin.left}
-                  scale={zoomedXScale}
-                  stroke="#333"
-                  tickStroke="#333"
-                  tickFormat={(value) => {
-                    const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
-                    return date.getDate().toString();
-                  }}
-                  tickLabelProps={() => ({ 
-                    fill: '#333', 
-                    fontSize: 11, 
-                    textAnchor: 'middle' 
-                  })}
-                />
-                {/* Month level axis */}
-                <AxisBottom
-                  top={rowHeight + margin.top + 60}
-                  left={margin.left}
-                  scale={zoomedXScale}
-                  tickFormat={(value) => {
-                    const date = value instanceof Date ? value : new Date(Number(value.valueOf()));
-                    return new Intl.DateTimeFormat('en-US', { month: 'short' }).format(date);
-                  }}
-                  stroke="#333"
-                  tickStroke="#333"
-                  tickLabelProps={() => ({ 
-                    fill: '#333', 
-                    fontSize: 12, 
-                    textAnchor: 'middle',
-                    fontWeight: 'bold'
-                  })}
-                />
-              </svg>
-            </>
-          );
-        }}
+        {(zoom) => (
+          <GanttZoomContent
+            zoom={zoom}
+            width={width}
+            height={height}
+            rowHeight={rowHeight}
+            xMax={xMax}
+            margin={margin}
+            ganttTasks={ganttTasks}
+            hugeDomain={hugeDomain}
+            xScale={xScale}
+            svgRef={svgRef}
+            jobs={jobs}
+            onJobClick={onJobClick}
+            onMouseDown={onMouseDown}
+            dragOperation={dragOperation}
+            draggedTask={draggedTask}
+            dragStartPosition={dragStartPosition}
+            setDraggedTask={setDraggedTask}
+            handleDragEnd={handleDragEnd}
+            getCursorStyle={getCursorStyle}
+            panning={panning}
+            middlePanning={middlePanning}
+            showTooltip={showTooltip}
+            hideTooltip={hideTooltip}
+          />
+        )}
       </Zoom>
       {tooltipData && !dragOperation && (
         <TooltipInPortal top={tooltipTop} left={tooltipLeft} style={tooltipStyles}>

--- a/src/components/JobForm.tsx
+++ b/src/components/JobForm.tsx
@@ -286,11 +286,11 @@ const JobForm: React.FC<JobFormProps> = ({ job, onSubmit, onCancel, onSketchSave
           {job && onDelete && (
             <button 
               type="button" 
-              onClick={() => {
-                if (window.confirm('Are you sure you want to delete this job? This action cannot be undone.')) {
-                  job.id && onDelete(job.id);
-                }
-              }} 
+                onClick={() => {
+                  if (window.confirm('Are you sure you want to delete this job? This action cannot be undone.') && job.id) {
+                    onDelete(job.id);
+                  }
+                }}
               title="Delete Job"
               className="p-1 rounded-full text-red-500 hover:bg-red-50 hover:text-red-700"
             >

--- a/src/types/d3-time.d.ts
+++ b/src/types/d3-time.d.ts
@@ -1,10 +1,20 @@
 // Type definitions for d3-time (minimal, for use in GanttChart)
 // This file can be extended as needed for more d3-time features.
 declare module 'd3-time' {
-  export const timeMinute: {
-    every(step: number): any;
+  export interface CountableTimeInterval {
+    (date: Date): Date;
+    floor(date: Date): Date;
+    round(date: Date): Date;
+    ceil(date: Date): Date;
+    offset(date: Date, step?: number): Date;
+    range(start: Date, stop: Date, step?: number): Date[];
+  }
+
+  export const timeMinute: CountableTimeInterval & {
+    every(step: number): CountableTimeInterval | null;
   };
-  export const timeHour: {
-    every(step: number): any;
+
+  export const timeHour: CountableTimeInterval & {
+    every(step: number): CountableTimeInterval | null;
   };
 }


### PR DESCRIPTION
## Summary
- guard archived job filtering against null values and share a memoized search pipeline
- refactor the Gantt chart into a hook-compliant component with typed zoom helpers and drag handling
- tighten ancillary lint fixes including job deletion confirmation and local d3-time types

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e2f13deda083298e4d6292b53c0694